### PR TITLE
Fix block start

### DIFF
--- a/compose/sbcp/sequencer.go
+++ b/compose/sbcp/sequencer.go
@@ -184,7 +184,7 @@ func (s *sequencer) BeginBlock(blockNumber BlockNumber) error {
 	}
 
 	if s.Head != 0 && blockNumber != s.Head+1 {
-		fmt.Println("shota ErrBlockNotSequential", blockNumber, s.Head)
+		fmt.Println("shota -- ErrBlockNotSequential", blockNumber, s.Head)
 		return ErrBlockNotSequential
 	}
 

--- a/compose/sbcp/sequencer.go
+++ b/compose/sbcp/sequencer.go
@@ -3,7 +3,6 @@ package sbcp
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/compose-network/specs/compose"
@@ -15,7 +14,7 @@ var (
 		"block number to be sealed does not match the current block number",
 	)
 	ErrBlockAlreadyOpen         = errors.New("there is already an open block")
-	ErrBlockNotSequential       = errors.New("block number is not sequential-1")
+	ErrBlockNotSequential       = errors.New("block number is not sequential")
 	NoPendingBlock              = errors.New("no pending block")
 	ErrActiveInstanceExists     = errors.New("there is already an active instance")
 	ErrNoActiveInstance         = errors.New("no active instance")
@@ -175,16 +174,13 @@ func (s *sequencer) startSettlement(ctx context.Context, periodID compose.Period
 
 // BeginBlock is a hook called at the start of a new L2 block.
 func (s *sequencer) BeginBlock(blockNumber BlockNumber) error {
-	fmt.Println("shota BeginBlock", blockNumber)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	fmt.Println("shota BeginBlock 2", blockNumber)
 	if s.PendingBlock != nil {
 		return ErrBlockAlreadyOpen
 	}
 
 	if s.Head != 0 && blockNumber != s.Head+1 {
-		fmt.Println("shota -- ErrBlockNotSequential", blockNumber, s.Head)
 		return ErrBlockNotSequential
 	}
 
@@ -279,7 +275,6 @@ func (s *sequencer) EndBlock(ctx context.Context, b BlockHeader) error {
 	settlementPeriod := s.PeriodID - 1
 	settlementSuperblock := s.TargetSuperblockNumber - 1
 
-	fmt.Println("shota Endblock")
 	s.PendingBlock = nil
 	s.Head = b.Number
 
@@ -332,7 +327,6 @@ func (s *sequencer) Rollback(
 	}
 
 	// Discard current block and active instance
-	fmt.Println("shota Endblock")
 	s.PendingBlock = nil
 	s.ActiveInstanceID = nil
 	s.Head = s.SettledState.BlockHeader.Number

--- a/compose/sbcp/sequencer.go
+++ b/compose/sbcp/sequencer.go
@@ -3,6 +3,7 @@ package sbcp
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/compose-network/specs/compose"
@@ -14,7 +15,7 @@ var (
 		"block number to be sealed does not match the current block number",
 	)
 	ErrBlockAlreadyOpen         = errors.New("there is already an open block")
-	ErrBlockNotSequential       = errors.New("block number is not sequential")
+	ErrBlockNotSequential       = errors.New("block number is not sequential-1")
 	NoPendingBlock              = errors.New("no pending block")
 	ErrActiveInstanceExists     = errors.New("there is already an active instance")
 	ErrNoActiveInstance         = errors.New("no active instance")
@@ -174,19 +175,20 @@ func (s *sequencer) startSettlement(ctx context.Context, periodID compose.Period
 
 // BeginBlock is a hook called at the start of a new L2 block.
 func (s *sequencer) BeginBlock(blockNumber BlockNumber) error {
+	fmt.Println("shota BeginBlock", blockNumber)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
+	fmt.Println("shota BeginBlock 2", blockNumber)
 	if s.PendingBlock != nil {
 		return ErrBlockAlreadyOpen
 	}
 
 	if blockNumber != s.Head+1 {
+		fmt.Println("shota ErrBlockNotSequential", blockNumber, s.Head)
 		return ErrBlockNotSequential
 	}
 
 	s.logger.Info().Uint64("new_block_number", uint64(blockNumber)).Msg("Beginning block")
-
 	// Add immutable tags to the new block
 	s.PendingBlock = &PendingBlock{
 		Number:           blockNumber,
@@ -277,6 +279,7 @@ func (s *sequencer) EndBlock(ctx context.Context, b BlockHeader) error {
 	settlementPeriod := s.PeriodID - 1
 	settlementSuperblock := s.TargetSuperblockNumber - 1
 
+	fmt.Println("shota Endblock")
 	s.PendingBlock = nil
 	s.Head = b.Number
 
@@ -329,6 +332,7 @@ func (s *sequencer) Rollback(
 	}
 
 	// Discard current block and active instance
+	fmt.Println("shota Endblock")
 	s.PendingBlock = nil
 	s.ActiveInstanceID = nil
 	s.Head = s.SettledState.BlockHeader.Number

--- a/compose/sbcp/sequencer.go
+++ b/compose/sbcp/sequencer.go
@@ -176,6 +176,7 @@ func (s *sequencer) startSettlement(ctx context.Context, periodID compose.Period
 func (s *sequencer) BeginBlock(blockNumber BlockNumber) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
 	if s.PendingBlock != nil {
 		return ErrBlockAlreadyOpen
 	}
@@ -185,6 +186,7 @@ func (s *sequencer) BeginBlock(blockNumber BlockNumber) error {
 	}
 
 	s.logger.Info().Uint64("new_block_number", uint64(blockNumber)).Msg("Beginning block")
+
 	// Add immutable tags to the new block
 	s.PendingBlock = &PendingBlock{
 		Number:           blockNumber,

--- a/compose/sbcp/sequencer.go
+++ b/compose/sbcp/sequencer.go
@@ -183,7 +183,7 @@ func (s *sequencer) BeginBlock(blockNumber BlockNumber) error {
 		return ErrBlockAlreadyOpen
 	}
 
-	if blockNumber != s.Head+1 {
+	if s.Head != 0 && blockNumber != s.Head+1 {
 		fmt.Println("shota ErrBlockNotSequential", blockNumber, s.Head)
 		return ErrBlockNotSequential
 	}


### PR DESCRIPTION
Tests start with loading most recent local head block which is not 1 but some other number (like 48). In `BeginBlock` function we expect the next block to be "next", so the block number is 0 and in the beginning we expect the next number 1 but in this case it's 48 and starting a new block fails.

Will this approach work? so we simply allow first block to be any number but still expect every other block sequentially increasing.

For tests this fixed the issue but should we leave this for prod environment or is there some other solution? (or is it guaranteed that the first block will be number 1)