### PR TITLE
feat(scp): add detailed logging for unfulfilled mailbox reads on timeout

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -30,6 +30,10 @@ func (id InstanceID) String() string {
 	return hex.EncodeToString(id[:])
 }
 
+func (a EthAddress) String() string {
+	return "0x" + hex.EncodeToString(a[:])
+}
+
 type TransactionRequest struct {
 	ChainID      ChainID
 	Transactions [][]byte

--- a/compose/scp/sequencer.go
+++ b/compose/scp/sequencer.go
@@ -294,7 +294,7 @@ func (r *sequencerInstance) ProcessDecidedMessage(decided bool) error {
 }
 
 // Timeout is invoked when the timer fires.
-// If not already in waiting for decided or done state, terminates as rejected and sends Vote(false) to SP.
+// If not already in waiting for a decided or done state, terminates as rejected and sends Vote(false) to SP.
 func (r *sequencerInstance) Timeout() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -305,7 +305,21 @@ func (r *sequencerInstance) Timeout() {
 		return
 	}
 
+	if len(r.expectedReadRequests) > 0 {
+		for _, req := range r.expectedReadRequests {
+			r.logger.Warn().
+				Uint64("src_chain", uint64(req.SourceChainID)).
+				Uint64("dest_chain", uint64(req.DestChainID)).
+				Str("sender", fmt.Sprintf("%x", req.Sender[:])).
+				Str("receiver", fmt.Sprintf("%x", req.Receiver[:])).
+				Uint64("session_id", uint64(req.SessionID)).
+				Str("label", req.Label).
+				Msg("Timeout waiting for mailbox message: read(chainMessageSender, sender, sessionId, label)")
+		}
+	}
+
 	r.logger.Info().
+		Int("unfulfilled_reads", len(r.expectedReadRequests)).
 		Msg("Timeout occurred, rejecting instance")
 
 	r.state = SeqStateDone

--- a/compose/scp/sequencer.go
+++ b/compose/scp/sequencer.go
@@ -308,13 +308,14 @@ func (r *sequencerInstance) Timeout() {
 	if len(r.expectedReadRequests) > 0 {
 		for _, req := range r.expectedReadRequests {
 			r.logger.Warn().
+				Str("op", "read").
 				Uint64("src_chain", uint64(req.SourceChainID)).
 				Uint64("dest_chain", uint64(req.DestChainID)).
-				Str("sender", fmt.Sprintf("%x", req.Sender[:])).
-				Str("receiver", fmt.Sprintf("%x", req.Receiver[:])).
+				Str("sender", req.Sender.String()).
+				Str("receiver", req.Receiver.String()).
 				Uint64("session_id", uint64(req.SessionID)).
 				Str("label", req.Label).
-				Msg("Timeout waiting for mailbox message: read(chainMessageSender, sender, sessionId, label)")
+				Msg("Unfulfilled mailbox request")
 		}
 	}
 


### PR DESCRIPTION
  - Log unfulfilled read requests with full context (op, src/dest chain, sender, receiver, session_id, label) when sequencer times out
  - Add EthAddress.String() method with 0x prefix
  - Add timeout tests for sequencer