### PR TITLE
proto: add instance helpers for working with proto types

### DIFF
--- a/compose/proto/instance.go
+++ b/compose/proto/instance.go
@@ -2,6 +2,8 @@ package proto
 
 import "encoding/hex"
 
+// InstanceIDHex returns the instance ID as a lowercase hex string.
+// Returns empty string if receiver is nil.
 func (x *StartInstance) InstanceIDHex() string {
 	if x == nil {
 		return ""
@@ -9,6 +11,8 @@ func (x *StartInstance) InstanceIDHex() string {
 	return hex.EncodeToString(x.GetInstanceId())
 }
 
+// InstanceIDHex returns the instance ID as a lowercase hex string.
+// Returns empty string if receiver is nil.
 func (x *Vote) InstanceIDHex() string {
 	if x == nil {
 		return ""
@@ -16,6 +20,8 @@ func (x *Vote) InstanceIDHex() string {
 	return hex.EncodeToString(x.GetInstanceId())
 }
 
+// InstanceIDHex returns the instance ID as a lowercase hex string.
+// Returns empty string if receiver is nil.
 func (x *Decided) InstanceIDHex() string {
 	if x == nil {
 		return ""

--- a/compose/proto/instance.go
+++ b/compose/proto/instance.go
@@ -22,14 +22,3 @@ func (x *Decided) InstanceIDHex() string {
 	}
 	return hex.EncodeToString(x.GetInstanceId())
 }
-
-func (x *XTRequest) TransactionsByChain() map[uint64][][]byte {
-	if x == nil {
-		return nil
-	}
-	m := make(map[uint64][][]byte, len(x.GetTransactionRequests()))
-	for _, req := range x.GetTransactionRequests() {
-		m[req.GetChainId()] = req.GetTransaction()
-	}
-	return m
-}

--- a/compose/proto/instance.go
+++ b/compose/proto/instance.go
@@ -3,7 +3,7 @@ package proto
 import "encoding/hex"
 
 // InstanceIDHex returns the instance ID as a lowercase hex string.
-// Returns empty string if receiver is nil.
+// Returns empty string if the receiver is nil.
 func (x *StartInstance) InstanceIDHex() string {
 	if x == nil {
 		return ""
@@ -12,7 +12,7 @@ func (x *StartInstance) InstanceIDHex() string {
 }
 
 // InstanceIDHex returns the instance ID as a lowercase hex string.
-// Returns empty string if receiver is nil.
+// Returns empty string if the receiver is nil.
 func (x *Vote) InstanceIDHex() string {
 	if x == nil {
 		return ""
@@ -21,7 +21,7 @@ func (x *Vote) InstanceIDHex() string {
 }
 
 // InstanceIDHex returns the instance ID as a lowercase hex string.
-// Returns empty string if receiver is nil.
+// Returns empty string if the receiver is nil.
 func (x *Decided) InstanceIDHex() string {
 	if x == nil {
 		return ""

--- a/compose/proto/instance.go
+++ b/compose/proto/instance.go
@@ -1,0 +1,35 @@
+package proto
+
+import "encoding/hex"
+
+func (x *StartInstance) InstanceIDHex() string {
+	if x == nil {
+		return ""
+	}
+	return hex.EncodeToString(x.GetInstanceId())
+}
+
+func (x *Vote) InstanceIDHex() string {
+	if x == nil {
+		return ""
+	}
+	return hex.EncodeToString(x.GetInstanceId())
+}
+
+func (x *Decided) InstanceIDHex() string {
+	if x == nil {
+		return ""
+	}
+	return hex.EncodeToString(x.GetInstanceId())
+}
+
+func (x *XTRequest) TransactionsByChain() map[uint64][][]byte {
+	if x == nil {
+		return nil
+	}
+	m := make(map[uint64][][]byte, len(x.GetTransactionRequests()))
+	for _, req := range x.GetTransactionRequests() {
+		m[req.GetChainId()] = req.GetTransaction()
+	}
+	return m
+}

--- a/compose/proto/instance_test.go
+++ b/compose/proto/instance_test.go
@@ -1,0 +1,50 @@
+package proto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInstanceIDHex(t *testing.T) {
+	id := []byte{0xde, 0xad, 0xbe, 0xef}
+
+	si := &StartInstance{InstanceId: id}
+	assert.Equal(t, "deadbeef", si.InstanceIDHex())
+
+	v := &Vote{InstanceId: id}
+	assert.Equal(t, "deadbeef", v.InstanceIDHex())
+
+	d := &Decided{InstanceId: id}
+	assert.Equal(t, "deadbeef", d.InstanceIDHex())
+}
+
+func TestInstanceIDHex_Nil(t *testing.T) {
+	var si *StartInstance
+	assert.Empty(t, si.InstanceIDHex())
+
+	var v *Vote
+	assert.Empty(t, v.InstanceIDHex())
+
+	var d *Decided
+	assert.Empty(t, d.InstanceIDHex())
+}
+
+func TestTransactionsByChain(t *testing.T) {
+	req := &XTRequest{
+		TransactionRequests: []*TransactionRequest{
+			{ChainId: 901, Transaction: [][]byte{{0x01}, {0x02}}},
+			{ChainId: 902, Transaction: [][]byte{{0x03}}},
+		},
+	}
+
+	m := req.TransactionsByChain()
+	assert.Len(t, m, 2)
+	assert.Equal(t, [][]byte{{0x01}, {0x02}}, m[901])
+	assert.Equal(t, [][]byte{{0x03}}, m[902])
+}
+
+func TestTransactionsByChain_Nil(t *testing.T) {
+	var req *XTRequest
+	assert.Nil(t, req.TransactionsByChain())
+}

--- a/compose/proto/instance_test.go
+++ b/compose/proto/instance_test.go
@@ -29,22 +29,3 @@ func TestInstanceIDHex_Nil(t *testing.T) {
 	var d *Decided
 	assert.Empty(t, d.InstanceIDHex())
 }
-
-func TestTransactionsByChain(t *testing.T) {
-	req := &XTRequest{
-		TransactionRequests: []*TransactionRequest{
-			{ChainId: 901, Transaction: [][]byte{{0x01}, {0x02}}},
-			{ChainId: 902, Transaction: [][]byte{{0x03}}},
-		},
-	}
-
-	m := req.TransactionsByChain()
-	assert.Len(t, m, 2)
-	assert.Equal(t, [][]byte{{0x01}, {0x02}}, m[901])
-	assert.Equal(t, [][]byte{{0x03}}, m[902])
-}
-
-func TestTransactionsByChain_Nil(t *testing.T) {
-	var req *XTRequest
-	assert.Nil(t, req.TransactionsByChain())
-}

--- a/compose/proto/request.go
+++ b/compose/proto/request.go
@@ -2,7 +2,7 @@ package proto
 
 // TransactionsByChain returns transactions grouped by chain ID.
 // The key is the chain ID, value is the list of raw transaction bytes.
-// Returns nil if receiver is nil.
+// Returns nil if the receiver is nil.
 func (x *XTRequest) TransactionsByChain() map[uint64][][]byte {
 	if x == nil {
 		return nil

--- a/compose/proto/request.go
+++ b/compose/proto/request.go
@@ -1,5 +1,8 @@
 package proto
 
+// TransactionsByChain returns transactions grouped by chain ID.
+// The key is the chain ID, value is the list of raw transaction bytes.
+// Returns nil if receiver is nil.
 func (x *XTRequest) TransactionsByChain() map[uint64][][]byte {
 	if x == nil {
 		return nil

--- a/compose/proto/request.go
+++ b/compose/proto/request.go
@@ -1,0 +1,12 @@
+package proto
+
+func (x *XTRequest) TransactionsByChain() map[uint64][][]byte {
+	if x == nil {
+		return nil
+	}
+	m := make(map[uint64][][]byte, len(x.GetTransactionRequests()))
+	for _, req := range x.GetTransactionRequests() {
+		m[req.GetChainId()] = req.GetTransaction()
+	}
+	return m
+}

--- a/compose/proto/request_test.go
+++ b/compose/proto/request_test.go
@@ -1,0 +1,26 @@
+package proto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransactionsByChain(t *testing.T) {
+	req := &XTRequest{
+		TransactionRequests: []*TransactionRequest{
+			{ChainId: 901, Transaction: [][]byte{{0x01}, {0x02}}},
+			{ChainId: 902, Transaction: [][]byte{{0x03}}},
+		},
+	}
+
+	m := req.TransactionsByChain()
+	assert.Len(t, m, 2)
+	assert.Equal(t, [][]byte{{0x01}, {0x02}}, m[901])
+	assert.Equal(t, [][]byte{{0x03}}, m[902])
+}
+
+func TestTransactionsByChain_Nil(t *testing.T) {
+	var req *XTRequest
+	assert.Nil(t, req.TransactionsByChain())
+}


### PR DESCRIPTION
Add minimal helper methods on generated proto types:
- InstanceIDHex() on StartInstance, Vote, Decided for hex encoding
- TransactionsByChain() on XTRequest for extracting transactions